### PR TITLE
redirect with query string

### DIFF
--- a/src/dderl.erl
+++ b/src/dderl.erl
@@ -98,9 +98,9 @@ init(Req, '$path_probe') ->
     {Code, Resp} = ?PROBE_RESP,
     {ok, cowboy_req:reply(Code, #{}, Resp, Req), undefined};
 init(Req, State) ->
-    Url = iolist_to_binary(cowboy_req:uri(Req)),
+    #{path := Path} = Req,
     Req1 =
-    case binary:last(Url) of
+    case binary:last(Path) of
         $/ ->
             Priv = priv_dir(),
             Filename = filename:join([Priv, "public", "dist", "index.html"]),
@@ -122,7 +122,13 @@ init(Req, State) ->
                     )
             end;
         _ ->
-            cowboy_req:reply(301, #{<<"location">> => <<Url/binary,"/">>}, Req)
+            Url = iolist_to_binary(cowboy_req:uri(Req, #{qs => undefined})),
+            QsBin =
+            case Req of
+                #{qs := <<>>} -> <<>>;
+                #{qs := Qs} -> <<"?", Qs/binary>>
+            end,
+            cowboy_req:reply(301, #{<<"location">> => <<Url/binary,"/",QsBin/binary>>}, Req)
     end,
     {ok, Req1, State}.
 


### PR DESCRIPTION
Url : `https://localhost:8443/dderl?test=123` was getting redirected to `https://localhost:8443/dderl?test=123/` it should be redirected as `https://localhost:8443/dderl/?test=123`